### PR TITLE
Support custom substitution value

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Note that all the files named 'x??.js' in data are derived directly from the equ
     > unidecode("に間違いがないか、再度確認してください。再読み込みしてください。");
     'niJian Wei iganaika, Zai Du Que Ren sitekudasai. Zai Du miIp misitekudasai. '
 
+## Advanced Usage
+
+### Custom Substitution Values
+
+For values that cannot be translated, empty strings are returned. You can override this behavior by passing a custom substitution value as the second argument to `unidecode`:
+
+    $ node
+    > var unidecode = require('unidecode');
+    > unidecode("ab\uFFFFc", "X");
+    'abXc'
+    > unidecode("ab\uFFFFc");
+    'abc'
+
 ## [Changelog](/CHANGELOG.md)
 
 ## Donate

--- a/test/unidecode.mocha.js
+++ b/test/unidecode.mocha.js
@@ -81,3 +81,19 @@ describe('# Complex tests', function(){
 		});
 	});
 });
+
+describe('# Custom substitution value tests', function(){
+
+	var tests = [
+		["ab\uFFFFc", "X", "abXc"],
+		["12\ud900\u1b003", " ", "12  3"]
+	];
+	
+	tests.forEach(function(test) {
+		it('{' + test[1] + '} ' + test[0] + '-->' + test[2], function(){
+			var exp = test[2];
+			var res = unidecode(test[0], test[1]);
+			assert.equal(res, exp);
+		});
+	});
+});


### PR DESCRIPTION
Closes #27 

This update adds a `sub` parameter to the main unidecode function which specifies the value to replace untranslatable characters with. If no suitable replacement character is found because the hex value is out of range, the value is invalid, or simply because the translation file returned an empty string, the provided `sub` value will be used instead.

For backwards compatibility, if no `sub` value is provided, an empty string will be used for the `sub` value.